### PR TITLE
Sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-referer` will be documented in this file
 
+## 1.2.0 - 2017-02-08
+- **Breaking**: Sources are now configured via `Source` implementations
+- **Breaking**: The configuration key `referer.key` has been renamed to `referer.session_key`
+
 ## 1.1.1 - 2017-02-07
 - Fixed: Fixed a regression that was introduced in 1.1.0
 

--- a/config/referer.php
+++ b/config/referer.php
@@ -5,7 +5,7 @@ return [
     /*
      * The key that will be used to remember the referer in the session.
      */
-    'key' => 'referer',
+    'session_key' => 'referer',
 
     /*
      * The sources used to determine the referer.

--- a/config/referer.php
+++ b/config/referer.php
@@ -11,7 +11,7 @@ return [
      * The sources used to determine the referer.
      */
     'sources' => [
-        'utm_source' => true,
-        'referer_header' => true,
+        Spatie\Referer\Sources\UtmSource::class,
+        Spatie\Referer\Sources\RequestHeader::class,
     ],
 ];

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -6,8 +6,8 @@ use Exception;
 
 class InvalidConfiguration extends Exception
 {
-    public static function emptyKey(): self
+    public static function emptySessionKey(): self
     {
-        return new self("`referer.key` can't be empty");
+        return new self("`referer.session_key` can't be empty");
     }
 }

--- a/src/Referer.php
+++ b/src/Referer.php
@@ -55,7 +55,7 @@ class Referer
     protected function determineFromRequest(Request $request): string
     {
         foreach ($this->sources as $source) {
-            if ($referer = app($source)->getReferer($request)) {
+            if ($referer = (new $source)->getReferer($request)) {
                 return $referer;
             }
         }

--- a/src/Referer.php
+++ b/src/Referer.php
@@ -9,7 +9,7 @@ use Spatie\Referer\Exceptions\InvalidConfiguration;
 class Referer
 {
     /** @var string */
-    protected $key;
+    protected $sessionKey;
 
     /** @var array */
     protected $sources;
@@ -17,30 +17,30 @@ class Referer
     /** @var \Illuminate\Contracts\Session\Session */
     protected $session;
 
-    public function __construct(string $key, array $sources, Session $session)
+    public function __construct(string $sessionKey, array $sources, Session $session)
     {
-        if (empty($key)) {
-            throw InvalidConfiguration::emptyKey();
+        if (empty($sessionKey)) {
+            throw InvalidConfiguration::emptySessionKey();
         }
 
-        $this->key = $key;
+        $this->sessionKey = $sessionKey;
         $this->sources = $sources;
         $this->session = $session;
     }
 
     public function get(): string
     {
-        return $this->session->get($this->key, '');
+        return $this->session->get($this->sessionKey, '');
     }
 
     public function forget()
     {
-        $this->session->forget($this->key);
+        $this->session->forget($this->sessionKey);
     }
 
     public function put(string $referer)
     {
-        return $this->session->put($this->key, $referer);
+        return $this->session->put($this->sessionKey, $referer);
     }
 
     public function putFromRequest(Request $request)

--- a/src/RefererServiceProvider.php
+++ b/src/RefererServiceProvider.php
@@ -24,15 +24,15 @@ class RefererServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/referer.php', 'referer');
 
         $this->app->when(Referer::class)
-            ->needs('$key')
+            ->needs('$sessionKey')
             ->give(function () {
-                return config('referer.key');
+                return $this->app['config']->get('referer.session_key');
             });
 
         $this->app->when(Referer::class)
             ->needs('$sources')
             ->give(function () {
-                return config('referer.sources', []);
+                return $this->app['config']->get('referer.sources', []);
             });
 
         $this->app->singleton(Referer::class);

--- a/src/RefererServiceProvider.php
+++ b/src/RefererServiceProvider.php
@@ -25,7 +25,15 @@ class RefererServiceProvider extends ServiceProvider
 
         $this->app->when(Referer::class)
             ->needs('$key')
-            ->give(config('referer.key'));
+            ->give(function () {
+                return config('referer.key');
+            });
+
+        $this->app->when(Referer::class)
+            ->needs('$sources')
+            ->give(function () {
+                return config('referer.sources', []);
+            });
 
         $this->app->singleton(Referer::class);
         $this->app->alias(Referer::class, 'referer');

--- a/src/Source.php
+++ b/src/Source.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Referer;
+
+use Illuminate\Http\Request;
+
+interface Source
+{
+    /**
+     * Retrieve a referer from a request. If no referer was found, return an empty string.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return string
+     */
+    public function getReferer(Request $request): string;
+}

--- a/src/Sources/RequestHeader.php
+++ b/src/Sources/RequestHeader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\Referer\Sources;
+
+use Illuminate\Http\Request;
+use Spatie\Referer\Helpers\Url;
+use Spatie\Referer\Source;
+
+class RequestHeader implements Source
+{
+    public function getReferer(Request $request): string
+    {
+        $referer = $request->header('referer', '');
+
+        if (empty($referer)) {
+            return '';
+        }
+
+        $refererHost = Url::host($referer);
+
+        if (empty($refererHost)) {
+            return '';
+        }
+
+        if ($refererHost === $request->getHost()) {
+            return '';
+        }
+
+        return $refererHost;
+    }
+}

--- a/src/Sources/UtmSource.php
+++ b/src/Sources/UtmSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\Referer\Sources;
+
+use Illuminate\Http\Request;
+use Spatie\Referer\Source;
+
+class UtmSource implements Source
+{
+    public function getReferer(Request $request): string
+    {
+        return $request->get('utm_source', '');
+    }
+}

--- a/tests/RefererTest.php
+++ b/tests/RefererTest.php
@@ -34,7 +34,9 @@ class RefererTest extends TestCase
     {
         $this->referer->put('google.com');
 
-        $this->assertEquals('google.com', $this->session->get(config('referer.key')));
+        $sessionKey = $this->app['config']->get('referer.session_key');
+        
+        $this->assertEquals('google.com', $this->session->get($sessionKey));
     }
 
     /** @test */

--- a/tests/RefererTest.php
+++ b/tests/RefererTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Referer\Test;
 
+use Spatie\Referer\Referer;
+
 class RefererTest extends TestCase
 {
     /** @test */
@@ -46,7 +48,7 @@ class RefererTest extends TestCase
     /** @test */
     public function it_cant_capture_the_referer_from_a_request_header_if_the_feature_is_disabled()
     {
-        config(['referer.sources.referer_header' => false]);
+        $this->withConfig(['referer.sources' => []]);
 
         $this->get('/', ['Referer' => 'https://google.com']);
 
@@ -64,7 +66,7 @@ class RefererTest extends TestCase
     /** @test */
     public function it_cant_capture_the_referer_from_an_utm_source_query_parameter_if_the_feature_is_disabled()
     {
-        config(['referer.sources.utm_source' => false]);
+        $this->withConfig(['referer.sources' => []]);
 
         $this->get('/?utm_source=google.com');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\Referer\Test;
 
 use Spatie\Referer\CaptureReferer;
+use Spatie\Referer\Referer;
 use Spatie\Referer\RefererServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -33,5 +34,14 @@ class TestCase extends Orchestra
         return [
             RefererServiceProvider::class,
         ];
+    }
+
+    protected function withConfig(array $config)
+    {
+        $this->app['config']->set($config);
+
+        $this->app->forgetInstance(Referer::class);
+
+        $this->referer = $this->app->make(Referer::class);
     }
 }


### PR DESCRIPTION
This PR turns the `sources` configuration to an array that accept classes which implement a `Source` interface, so developers van easily extend where the referer is determined.