### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/contracts": "~5.4.0",
-        "illuminate/http": "~5.4.0",
-        "illuminate/support": "~5.4.0"
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
+        "illuminate/http": "~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.3",
-        "phpunit/phpunit": "^5.7"
+        "orchestra/testbench": "~3.4.3|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
-        "illuminate/http": "~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.4.0|~5.5.x-dev"
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/http": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.3|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.3|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -49,3 +49,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-referer/phpunit.xml.dist

..............                                                    14 / 14 (100%)

Time: 2.35 seconds, Memory: 12.00MB

OK (14 tests, 14 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments