### PR TITLE
Fix use statement in the code example for "Forgetting or manually setting the referer" documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ An empty referer will never overwrite an exisiting referer. So if a visitor come
 The `Referer` class provides dedicated methods to forget, or manually set the referer.
 
 ```php
-use Referer;
+use Facades\Spatie\Referer\Referer;
 
 Referer::put('google.com');
 Referer::get(); // 'google.com'


### PR DESCRIPTION
The code example is using the real-time facade, so this pull request just changes the use import statement to reflect that.